### PR TITLE
add expose headers functionality

### DIFF
--- a/src/cors/index.js
+++ b/src/cors/index.js
@@ -3,7 +3,7 @@ const curry = require('curry');
 const trim = (s) => s.trim();
 const lowercase = (s) => s.toLowerCase();
 
-const cors = ({ allowOrigin, allowMethods = ['GET'], allowHeaders = [] }, next) => (req, res) => {
+const cors = ({ allowOrigin, allowMethods = ['GET'], allowHeaders = [], exposeHeaders = [] }, next) => (req, res) => {
   if (!req.headers.origin) {
     return next(req, res);
   }
@@ -23,6 +23,10 @@ const cors = ({ allowOrigin, allowMethods = ['GET'], allowHeaders = [] }, next) 
   }
 
   const requestedHeaders = req.header('Access-Control-Request-Headers');
+
+  if (exposeHeaders.length > 0) {
+    res.set('Access-Control-Expose-Headers', exposeHeaders.join(', '));
+  }
 
   if (requestedHeaders) {
     const allowed = requestedHeaders.split(',').map(trim).map(lowercase).filter((header) =>

--- a/test/cors.js
+++ b/test/cors.js
@@ -137,6 +137,15 @@ describe('gcframe-cors', () => {
       assert(next.calledOnce);
       assert(next.calledWith(req, res));
     });
+    it('includes header with exposed headers listed', () => {
+      req.method = 'GET';
+      req.headers.origin = 'not.com';
+      cors({ allowOrigin: ['not.com'], exposeHeaders: ['Authorization', 'THING'] }, next)(req, res);
+
+      assert(res.set.calledWith('Access-Control-Expose-Headers', 'Authorization, THING'));
+      assert(next.calledOnce);
+      assert(next.calledWith(req, res));
+    });
   });
 
   describe('curried function', () => {


### PR DESCRIPTION
adds the ability to specify exposeHeaders array in CORS middleware
Setting the header: Access-Control-Expose-Headers